### PR TITLE
feat: add authenticated articles API endpoint with PintyPlus products

### DIFF
--- a/backend/app/controllers/api/articles_controller.rb
+++ b/backend/app/controllers/api/articles_controller.rb
@@ -1,0 +1,15 @@
+class Api::ArticlesController < ApiController
+  before_action :authenticate_customer_user!
+
+  def index
+    products = load_mock_products
+    render json: { products: products }
+  end
+
+  private
+
+  def load_mock_products
+    file_path = Rails.root.join("lib", "mock_products.json")
+    JSON.parse(File.read(file_path))
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -22,6 +22,11 @@ Rails.application.routes.draw do
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
+  # API routes
+  namespace :api do
+    get "articles", to: "articles#index"
+  end
+
   # Defines the root path route ("/")
   root "admin/dashboard#index"
 

--- a/backend/lib/mock_products.json
+++ b/backend/lib/mock_products.json
@@ -1,0 +1,102 @@
+[
+  {
+    "code": "PP-R1010-400",
+    "name": "Pintura Acrílica Roja Brillante",
+    "brand": "PintyPlus",
+    "size": "400ml",
+    "color": "Rojo",
+    "family": "Basic",
+    "units_per_box": 12,
+    "price": 8.50
+  },
+  {
+    "code": "PP-B2020-400",
+    "name": "Pintura Acrílica Azul Mate",
+    "brand": "PintyPlus",
+    "size": "400ml",
+    "color": "Azul",
+    "family": "Evolution",
+    "units_per_box": 12,
+    "price": 9.75
+  },
+  {
+    "code": "PP-V3030-200",
+    "name": "Pintura Acrílica Verde Satinada",
+    "brand": "PintyPlus",
+    "size": "200ml",
+    "color": "Verde",
+    "family": "Tech",
+    "units_per_box": 24,
+    "price": 6.25
+  },
+  {
+    "code": "PP-N4040-400",
+    "name": "Pintura Acrílica Negro Brillante",
+    "brand": "PintyPlus",
+    "size": "400ml",
+    "color": "Negro",
+    "family": "Basic",
+    "units_per_box": 12,
+    "price": 8.50
+  },
+  {
+    "code": "PP-B5050-600",
+    "name": "Pintura Acrílica Blanco Mate",
+    "brand": "PintyPlus",
+    "size": "600ml",
+    "color": "Blanco",
+    "family": "Evolution",
+    "units_per_box": 6,
+    "price": 12.90
+  },
+  {
+    "code": "PP-A6060-400",
+    "name": "Pintura Acrílica Amarillo Brillante",
+    "brand": "PintyPlus",
+    "size": "400ml",
+    "color": "Amarillo",
+    "family": "Tech",
+    "units_per_box": 12,
+    "price": 9.25
+  },
+  {
+    "code": "PP-G7070-200",
+    "name": "Pintura Acrílica Gris Satinado",
+    "brand": "PintyPlus",
+    "size": "200ml",
+    "color": "Gris",
+    "family": "Basic",
+    "units_per_box": 24,
+    "price": 5.95
+  },
+  {
+    "code": "PP-M8080-400",
+    "name": "Pintura Acrílica Marrón Mate",
+    "brand": "PintyPlus",
+    "size": "400ml",
+    "color": "Marrón",
+    "family": "Evolution",
+    "units_per_box": 12,
+    "price": 8.75
+  },
+  {
+    "code": "PP-O9090-600",
+    "name": "Pintura Acrílica Naranja Brillante",
+    "brand": "PintyPlus",
+    "size": "600ml",
+    "color": "Naranja",
+    "family": "Tech",
+    "units_per_box": 6,
+    "price": 13.45
+  },
+  {
+    "code": "PP-P1000-400",
+    "name": "Pintura Acrílica Púrpura Satinada",
+    "brand": "PintyPlus",
+    "size": "400ml",
+    "color": "Púrpura",
+    "family": "Evolution",
+    "units_per_box": 12,
+    "price": 10.20
+  }
+]

--- a/backend/test/integration/articles_test.rb
+++ b/backend/test/integration/articles_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class ArticlesTest < ActionDispatch::IntegrationTest
+  def setup
+    @active_user = customer_users(:one)
+    @active_user.update!(
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    @blocked_user = customer_users(:two)
+    @blocked_user.update!(
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  test "authenticated request returns articles with valid token" do
+    # Login to get tokens
+    post "/auth/sign_in", params: {
+      email: @active_user.email,
+      password: "password123"
+    }
+
+    assert_response :ok
+
+    # Extract tokens
+    access_token = response.headers["access-token"]
+    client = response.headers["client"]
+    uid = response.headers["uid"]
+
+    # Request articles with authentication
+    get "/api/articles", headers: {
+      "access-token" => access_token,
+      "client" => client,
+      "uid" => uid
+    }
+
+    assert_response :ok
+
+    json_response = JSON.parse(response.body)
+
+    # Check that we get an array of products
+    assert json_response["products"].is_a?(Array)
+    assert json_response["products"].length == 10
+
+    # Check first product has required attributes
+    first_product = json_response["products"].first
+    assert first_product["code"].present?
+    assert first_product["name"].present?
+    assert first_product["brand"] == "PintyPlus"
+    assert first_product["size"].present?
+    assert first_product["color"].present?
+    assert first_product["family"].present?
+    assert first_product["units_per_box"].present?
+    assert first_product["price"].present?
+  end
+
+  test "unauthenticated request returns unauthorized error" do
+    get "/api/articles"
+
+    assert_response :unauthorized
+  end
+
+  test "request with invalid token returns unauthorized error" do
+    get "/api/articles", headers: {
+      "access-token" => "invalid_token",
+      "client" => "invalid_client",
+      "uid" => "invalid@example.com"
+    }
+
+    assert_response :unauthorized
+  end
+end


### PR DESCRIPTION
- Add API::ArticlesController with Devise Token Auth authentication
- Create mock_products.json with 10 PintyPlus paint can products
- Add /api/articles GET endpoint returning mocked product data
- Include integration tests for authenticated and unauthenticated access
- Products include: code, name, brand, size, color, family, units_per_box, price