### PR TITLE
fix: remove orphaned admins table from database schema

### DIFF
--- a/backend/db/migrate/20250826063045_drop_unused_admins_table.rb
+++ b/backend/db/migrate/20250826063045_drop_unused_admins_table.rb
@@ -1,0 +1,5 @@
+class DropUnusedAdminsTable < ActiveRecord::Migration[8.0]
+  def change
+    drop_table :admins if table_exists?(:admins)
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_25_190254) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_26_063045) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -39,18 +39,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_25_190254) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
-  end
-
-  create_table "admins", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_admins_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
   create_table "customer_users", force: :cascade do |t|


### PR DESCRIPTION
Remove unused admins table that was left over from development and had no corresponding model or functionality. This table was identified as orphaned during code analysis.